### PR TITLE
Fix auth redirect for non-rooted applications

### DIFF
--- a/src/Controller/Component/RedirectComponent.php
+++ b/src/Controller/Component/RedirectComponent.php
@@ -39,7 +39,8 @@ class RedirectComponent extends Component
         
         $this->controller->redirect(Router::url([
             'plugin' => 'Beskhue/CookieTokenAuth', 
-            'controller' => 'CookieTokenAuth'
+            'controller' => 'CookieTokenAuth',
+            '_base' => false
         ]));
     }
     


### PR DESCRIPTION
There's an redirect issue for auth redirect to /auth/cookie-token-auth while running cakephp in an subdirectory. Something like http://domain.tld/path/to/application/ results in http://domain.tld/path/to/application/path/to/application/auth/cookie-token-auth
