### PR TITLE
Remove any prefix from a page that calls CookieTokenAuth when routing…

### DIFF
--- a/src/Controller/Component/CookieTokenComponent.php
+++ b/src/Controller/Component/CookieTokenComponent.php
@@ -73,6 +73,7 @@ class CookieTokenComponent extends Component
             'path' => Router::url([
                 'plugin' => 'Beskhue/CookieTokenAuth', 
                 'controller' => 'CookieTokenAuth',
+                'prefix' => false,
             ]),
             'encryption' => 'aes',
             'expires' => '-1 day',

--- a/src/Controller/Component/RedirectComponent.php
+++ b/src/Controller/Component/RedirectComponent.php
@@ -40,6 +40,7 @@ class RedirectComponent extends Component
         $this->controller->redirect(Router::url([
             'plugin' => 'Beskhue/CookieTokenAuth', 
             'controller' => 'CookieTokenAuth',
+            'prefix' => false,
             '_base' => false
         ]));
     }


### PR DESCRIPTION
… internally

I often use a prefix route in Cake routing to make "/admin" sections for my sites.  The prefix needs to be removed when CookeTokenAuth redirects internally otherwise the plugin can't find its various bits and pieces.